### PR TITLE
Improve responsive image delivery for hero images

### DIFF
--- a/src/components/PreviewPosts.astro
+++ b/src/components/PreviewPosts.astro
@@ -57,9 +57,8 @@ const sortedPosts = [...posts].sort((a, b) => {
                                     class="group-hover:scale-105 transition-all duration-200"
                                     src={post.data.heroImage}
                                     alt={post.data.title}
-                                    densities={[1, 2]}
-                                    width={400}
-                                    height={400}
+                                    widths={[300, 400, 600, 720, 800]}
+								    sizes="(max-width: 480px) 100vw, (max-width: 720px) 50vw, (max-width: 1024px) 33vw, 400px"
                                     format="webp"
                                     quality={75}
                                     loading="lazy"

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -65,16 +65,15 @@ const json_ld = heroImage
 					{
 						heroImage && (
 							<Image
-								densities={[1, 2]}
-								width={400}
-								height={400}
 								alt={title}
 								src={heroImage}
+								widths={[300, 400, 600, 720, 800]}
+								sizes="(max-width: 480px) 100vw, (max-width: 720px) 50vw, (max-width: 1024px) 33vw, 400px"
 								format="webp"
 								quality={75}
 								loading="lazy"
 								decoding="async"
-							/>
+								/>
 						)
 					}
 				</div>


### PR DESCRIPTION
- Refined <Image> component setup for article preview cards
- Added intermediate widths: [300, 400, 600, 720, 800]
- Adjusted sizes attribute to better reflect layout breakpoints:
  * 100vw for small screens
  * 50vw for tablets
  * 33vw for medium screens
  * Fixed 400px on large screens
- This setup improves loading performance and DPR (Retina) support
