### PR TITLE
Fix: Update Prettier config to correctly load Astro plugin

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,4 @@
 // prettier.config.js
-import { createRequire } from "module";
-const require = createRequire(import.meta.url);
-const astroPlugin = require("prettier-plugin-astro");
 
 /** @type {import("prettier").Options} */
 export default {
@@ -13,7 +10,8 @@ export default {
   trailingComma: "es5",
   bracketSpacing: true,
   arrowParens: "avoid",
-  plugins: [astroPlugin],
+  // Aquí es donde cambia: usa el nombre del módulo como string
+  plugins: ["prettier-plugin-astro"],
   overrides: [
     {
       files: "*.astro",


### PR DESCRIPTION
This commit resolves the 'The requested module "prettier-plugin-astro" does not provide an export named "default"' error encountered in GitHub Actions.

Previously, the Prettier configuration attempted to import 'prettier-plugin-astro' using an ES module default import. However, the plugin does not provide a default export, leading to a module resolution error during the CI/CD pipeline.

The fix involves updating  to reference 'prettier-plugin-astro' as a string in the  array. Prettier is designed to resolve plugins by their package name when provided as a string, correctly loading the plugin without expecting a specific export.

This change ensures consistent code formatting checks across local development and CI environments.

