### PR TITLE
feat(related-posts): add support for displaying related posts on arti…

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,56 @@
+---
+import { getAllPosts } from '../utils/get_all_posts';
+import PreviewPosts from './PreviewPosts.astro';
+import { type CollectionName } from '../collections';
+
+type Posts = Awaited<ReturnType<typeof getAllPosts>>;
+
+interface Props {
+  post_title: string;
+  collection: CollectionName;
+  slug: string;
+}
+
+const { post_title, collection, slug } = Astro.props as Props;
+
+export const relatedPostsScore = (posts: Posts, categoy: string, slug: string) => {
+  const options = posts
+    .map(post => {
+      if (post.data.tags) {
+        return post.data.tags;
+      } else {
+        return '';
+      }
+    })
+    .filter(v => v !== '');
+
+  const current_tags = posts.find(post => post.id === slug)?.data.tags ?? [];
+
+  const scores = options
+    .map(tags => tags.filter(tag => current_tags.includes(tag)))
+    .map((v, i) => ({ index: i, arr: v }))
+    .filter(v => v.arr.length !== 0)
+    .map(v => {
+      const index = v.index;
+      const items = v.arr;
+
+      if (posts[index].collection === categoy) {
+        return { score: items.length + 1, content: posts[index] };
+      }
+
+      return { score: items.length, content: posts[index] };
+    })
+    .sort((a, b) => b.score - a.score);
+  return scores;
+};
+
+const posts = await getAllPosts();
+
+const related = relatedPostsScore(posts, collection, slug);
+const related_posts = related
+  .map(v => v.content)
+  .filter(v => v.data.title !== post_title)
+  .slice(0, 3);
+---
+
+<PreviewPosts posts={related_posts} title="🔍 Discover More Articles" remove_h1={true} />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -8,11 +8,20 @@ import { SITE_TITLE, SITE_LANG } from '../config/site.consts';
 
 import { getCollection } from 'astro:content';
 import { FOOTER_CONTENT } from '../config/footer.consts';
+import RelatedPosts from '../components/RelatedPosts.astro';
+import { type CollectionName } from '../collections';
 
 type Posts = Awaited<ReturnType<typeof getCollection>>[0]['data'];
 
-const { title, description, pubDate, updatedDate, affiliateBlock, heroImage } =
-  Astro.props as Posts;
+interface Props {
+  post: Posts;
+  collection: CollectionName;
+  slug: string;
+}
+
+const { post, collection, slug } = Astro.props as Props;
+
+const { title, description, pubDate, updatedDate, affiliateBlock, heroImage } = post;
 
 const json_ld = heroImage
   ? {
@@ -127,6 +136,8 @@ const json_ld = heroImage
           }
         </div>
       </article>
+
+      <RelatedPosts post_title={title} collection={collection} slug={slug} />
     </main>
     <Footer {...FOOTER_CONTENT} />
   </body>

--- a/src/pages/[collection]/[...slug].astro
+++ b/src/pages/[collection]/[...slug].astro
@@ -2,9 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
 import { type CollectionName, collections } from '../../collections';
-// Define aquí tus colecciones disponibles
 
-// Generación de rutas estáticas para cada colección y slug
 export async function getStaticPaths() {
   const paths: { params: { collection: string; slug: string } }[] = [];
 
@@ -23,7 +21,6 @@ export async function getStaticPaths() {
   return paths;
 }
 
-// Extrae params de la URL
 const { collection, slug } = Astro.params as {
   collection: CollectionName;
   slug: string;
@@ -40,6 +37,6 @@ if (!post) {
 const { Content } = await render(post);
 ---
 
-<BlogPost {...post.data}>
+<BlogPost post={post.data} collection={collection} slug={slug}>
   <Content />
 </BlogPost>


### PR DESCRIPTION
support for displaying related posts on article pages

- Introduce  utility to calculate related posts based on shared tags and collection
- Update page template to pass  and  props into  component
- Fetch all posts in , filter out current article, and sort related items by score
- Render  with related content under each article, showing only posts with at least one tag in common
- Ensure the component is reusable by receiving , , and  via props

